### PR TITLE
add factory methods for DType

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/DType.java
+++ b/java/src/main/java/ai/rapids/cudf/DType.java
@@ -92,7 +92,6 @@ public final class DType {
     scale = 0;
   }
 
-  // TODO : Java docs for constructor and public methods
   /**
    * Constructor for Decimal Type
    * @param id Enum representing data type.
@@ -198,6 +197,30 @@ public final class DType {
   @Override
   public String toString() {
     return "" + typeId;
+  }
+
+  /**
+   * Factory method for non-decimal DType instances.
+   *
+   * @return DType
+   */
+  public static DType create(DTypeEnum dt) {
+    if (dt == DTypeEnum.DECIMAL32 || dt == DTypeEnum.DECIMAL64) {
+      throw new IllegalArgumentException("Could not create a Decimal DType without scale");
+    }
+    return DType.fromNative(dt.nativeId, 0);
+  }
+
+  /**
+   * Factory method specialized for decimal DType instances.
+   *
+   * @return DType
+   */
+  public static DType create(DTypeEnum dt, int scale) {
+    if (dt != DTypeEnum.DECIMAL32 && dt != DTypeEnum.DECIMAL64) {
+      throw new IllegalArgumentException("Could not create a non-Decimal DType with scale");
+    }
+    return DType.fromNative(dt.nativeId, scale);
   }
 
   public static DType fromNative(int nativeId, int scale) {

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -751,7 +751,7 @@ public class ColumnVectorTest extends CudfTestBase {
         case TIMESTAMP_MILLISECONDS:
         case TIMESTAMP_MICROSECONDS:
         case TIMESTAMP_NANOSECONDS:
-          s = Scalar.timestampFromLong(new DType(type, 0), 1234567890123456789L);
+          s = Scalar.timestampFromLong(DType.create(type), 1234567890123456789L);
           break;
         case STRING:
           s = Scalar.fromString("hello, world!");
@@ -763,7 +763,7 @@ public class ColumnVectorTest extends CudfTestBase {
         case DURATION_MILLISECONDS:
         case DURATION_MICROSECONDS:
         case DURATION_NANOSECONDS:
-          s = Scalar.durationFromLong(new DType(type, 0), 21313);
+          s = Scalar.durationFromLong(DType.create(type), 21313);
           break;
           case EMPTY:
           case LIST:
@@ -774,7 +774,7 @@ public class ColumnVectorTest extends CudfTestBase {
         }
 
         try (ColumnVector c = ColumnVector.fromScalar(s, 0)) {
-          assertEquals(type, c.getType().typeId);
+          assertEquals(DType.create(type), c.getType());
           assertEquals(0, c.getRowCount());
           assertEquals(0, c.getNullCount());
         }
@@ -968,7 +968,7 @@ public class ColumnVectorTest extends CudfTestBase {
           || type == DType.DTypeEnum.DECIMAL32 || type == DType.DTypeEnum.DECIMAL64) {
         continue;
       }
-      try (Scalar s = Scalar.fromNull(DType.fromNative(type.nativeId));
+      try (Scalar s = Scalar.fromNull(DType.create(type));
            ColumnVector c = ColumnVector.fromScalar(s, rowCount);
            HostColumnVector hc = c.copyToHost()) {
         assertEquals(type, c.getType().typeId);

--- a/java/src/test/java/ai/rapids/cudf/ScalarTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ScalarTest.java
@@ -49,7 +49,7 @@ public class ScalarTest extends CudfTestBase {
       if (dataType == DType.DTypeEnum.DECIMAL32 || dataType == DType.DTypeEnum.DECIMAL64) {
         continue;
       }
-      DType type= DType.fromNative(dataType.nativeId);
+      DType type = DType.create(dataType);
       if (!type.isNestedType()) {
         try (Scalar s = Scalar.fromNull(type)) {
           assertEquals(type, s.getType());


### PR DESCRIPTION
This  PR is trying to address two small issues.
1. After thinking about this more I believe that we want all of the constructors to be private and have a factory that you can use to create a DType instead. That way it can look at the enum and pull out the singleton if it matches. If we have multiple of these factories, one that takes a scale and one that does not, then we would need to enforce that a scale was provided when a DECIMAL type was passed in. I don't want the scale for a decimal to default to 0. It just opens up too many possibilities for errors.
2. (in ColumnVectorTest) Why not do all of this in terms of DType instead of DTypeEnum so we get the scale check in here too.